### PR TITLE
Added more options to use custom builds for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ Role Variables
 | gluster_cluster_disperse_count     | UNDEF     | Disperse count for the volume. If this value is specified, a dispersed volume will be created |
 | gluster_cluster_replica_count     | UNDEF     | Replica count while creating a volume. Currently replica 3 is supported.|
 | node0     | UNDEF     | one of the nodes of the cluster where profile info will be collected|
-| build     | UNDEF     | Which build to use for performance test it can be upstream or custom. In case of custom build you also need to provide a url of the custom build |
-| custom_build_url    | points to v8.1     | Url of the custom build to be used for perf test |
+| build     | UNDEF     | Which build to use for performance test it can be upstream or custom. In case of custom build you also need to provide one of the following : **custom_build_url,  custom_build_path, custom_build_repo_url** |
+| custom_build_url    | UNDEF     | Url of the custom build to be used for perf test |
+| custom_build_path    | UNDEF     | Local path of the rpms created |
+| custom_build_repo_url    | UNDEF     | Url of the custom build repository to be used for perf test |
 |  benchmarking_tools   | 0     | When set it will install the benmarking tools i.e. smallfile test and izone |
 |  backend_variables   | UNDEF     | Path to yaml file where backend variables are defined. The file backend-vars.sample from the repository, can  be copied and changed based on the disks available in your cluster. |
 |  cleanup_vars   | UNDEF     | Path to yaml file where cleanup variables are defined. The file cleanup-vars.sample from the repository, can be copied and changed based on the current configuration of your cluster. |

--- a/roles/remove-gluster-and-its-repositories/tasks/main.yml
+++ b/roles/remove-gluster-and-its-repositories/tasks/main.yml
@@ -15,7 +15,7 @@
   retries: 10
   delay: 5
 
-- name: Recursively remove directories
+- name: Deleting some files and directories from previous runs
   file:
     path: "{{ item }}"
     state: absent
@@ -23,6 +23,7 @@
     - /var/log/glusterfs/
     - /var/lib/glusterd/
     - /var/run/gluster/
+    - /etc/yum.repos.d/CustomGluster.repo
 
 - name: Remove Upstream and custom repository
   yum_repository:

--- a/roles/setup-custom-build-repo/defaults/main.yml
+++ b/roles/setup-custom-build-repo/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 tempdir: "/tmp/downloaded-gluster-rpms"
-custom_build_url: "https://download.gluster.org/pub/gluster/glusterfs/8/8.1/Fedora/fedora-32/x86_64/"

--- a/roles/setup-custom-build-repo/tasks/main.yml
+++ b/roles/setup-custom-build-repo/tasks/main.yml
@@ -26,12 +26,22 @@
     state: directory
     mode: '0755'
 
-- name: Download rpms
+- name: Download rpms from custom_build_url provided
   shell:
     cmd: wget -P "{{ tempdir }}" -r -nH --cut-dirs=100 --no-parent -A '*'  "{{ custom_build_url }}"
     chdir: "{{ tempdir }}"
   args:
     warn: false
+  when: custom_build_url is defined
+
+- name: Copy custom rpms from custom_build_path to remote machine
+  copy:
+    src: "{{ custom_build_path |  regex_replace('$', '/') }}"
+    dest: "{{ tempdir }}"
+    owner: root
+    group: root
+    mode: '0644'
+  when: custom_build_path is defined
 
 - name: Create local repository
   shell:
@@ -45,3 +55,10 @@
     gpgcheck: false
     repo_gpgcheck: false
     enabled: 1
+
+- name: downloading custom repository from given build_repo_url
+  get_url:
+    url: "{{ custom_build_repo_url }}"
+    dest: /etc/yum.repos.d/CustomGluster.repo
+    mode: '0644'
+  when: custom_build_repo_url is defined


### PR DESCRIPTION
To install custom builds we can now use:
- custom_build_url
- custom_build_repo_url
- custom_build_path

Generally the community developers would make changes in their code
and fire make glusterrpms, so they would be having the rpms but
not the url, which blocks them to use this utility to check the
performance of the changes made in their sandbox. With this option
provided it will become very easy for any body to check their changes
by using custom_build_path option.

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>