### PR TITLE
Skipping error if rsh is already present

### DIFF
--- a/roles/gluster-client-setup/tasks/main.yml
+++ b/roles/gluster-client-setup/tasks/main.yml
@@ -22,6 +22,7 @@
     group: root
     state: link
   when: inventory_hostname == groups['master_client'].0
+  ignore_errors: yes
 
 - name: distribute the ssh key to the remote hosts
   shell: "/usr/bin/sshpass -p \"{{ remote_machine_password }}\" ssh-copy-id -f -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/{{ ssh_key_filename }}.pub  \"{{ remote_machine_username }}@{{ item }}\""


### PR DESCRIPTION
rsh package has been deprecated from RHEL8
hence we create a symlink of rhs which points to
ssh. But on a machine where rsh is pre-existing
we get an error saying that we can't create symlink
so we need to ignore this error.

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>