### PR TITLE
Increased the timeout value so that test completes

### DIFF
--- a/roles/execute-perf-and-get-results/tasks/main.yml
+++ b/roles/execute-perf-and-get-results/tasks/main.yml
@@ -58,14 +58,14 @@
 
 - name: Run smallfile test
   shell: "/root/smallfile-test-for-fuse.sh \"{{node0}}\"  > /root/fuse-smallfile-result.txt 2>&1"
-  async: 21600                                 # waiting for 6 hours for test to complete, if it finishes early poll will detect that and report
+  async: 32400                                 # waiting for 9 hours for test to complete, if it finishes early poll will detect that and report
   poll: 900
   register: perf_test
   when: tool == "smallfile"
 
 - name: Run largefile test using izone
   shell: "/root/largefile-test-for-fuse.sh \"{{node0}}\" \"{{total_number_of_threads}}\" > /root/fuse-largefile-result.txt 2>&1"
-  async: 21600                                 # waiting for 6 hours for test to complete, if it finishes early poll will detect that and report
+  async: 32400                                 # waiting for 9 hours for test to complete, if it finishes early poll will detect that and report
   poll: 900
   register: perf_test
   when: tool == "iozone"


### PR DESCRIPTION
When the test takes more time to complete than the expected time,
its killed due to timeout. This patch allows the test to complete
so that we can get the required data for analysis to find out why
did the test take time.

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>