### PR TITLE
Give appropriate names to script parsing results

### DIFF
--- a/Executing-Perf-Test.md
+++ b/Executing-Perf-Test.md
@@ -194,10 +194,10 @@ Once the test is done you should be having the following files created on your c
 * fuse-iozone-result.txt
 * PerfTest.log
 
-You can run the small-file-result.sh to extract the results as follows:
+You can run the extract-smallfile-results.sh to extract the results as follows:
 
 ```
-$ ./small-file-result.sh ~/config-for-cluster1/results/fuse-smallfile-result.txt
+$ ./extract-smallfile-results.sh ~/config-for-cluster1/results/fuse-smallfile-result.txt
 create: 2636.48441375
 ls-l: 8807.125541
 chmod: 1736.76129275
@@ -211,10 +211,10 @@ rmdir: 464.1749462
 cleanup: 5541.57562475
 ```
 
-You can run the large-result-iozone.sh to extract the results as follows , note that here we have given the numbers of threads as 16, you can specify this as (number of clients * 4), so if you have 6 clients then the number would be 24.
+You can run the extract-iozone-results.sh to extract the results as follows , note that here we have given the numbers of threads as 16, you can specify this as (number of clients * 4), so if you have 6 clients then the number would be 24.
 
 ```
-$ ./large-result-iozone.sh ~/config-for-cluster1/results/fuse-iozone-result.txt 16
+$ ./extract-iozone-results.sh ~/config-for-cluster1/results/fuse-iozone-result.txt 16
 seq-write : 62147.61
 seq-read : 228799.186
 random-write : 64242.22

--- a/Generate-Report.sh
+++ b/Generate-Report.sh
@@ -4,7 +4,7 @@ if [ $# -ne 5  ]
 then
     echo; echo "Usage: $0 <script-to-extracts-the-result> <Baseline result> <Baseline log file> <Current results> <Current log file>"
     echo; echo "eg:"
-    echo; echo "    # $0 ./small-file-result.sh ~/config-for-cluster1/BaseLine-fuse-smallfile-result.txt ~/config-for-cluster1/BaselinePerfTest.log ./results/fuse-smallfile-result.txt ./results/PerfTest.log"
+    echo; echo "    # $0 ./extract-smallfile-results.sh ~/config-for-cluster1/BaseLine-fuse-smallfile-result.txt ~/config-for-cluster1/BaselinePerfTest.log ./results/fuse-smallfile-result.txt ./results/PerfTest.log"
     exit
 fi
 

--- a/extract-iozone-results.sh
+++ b/extract-iozone-results.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ $# -ne 2  ]
+then
+  echo; echo "Usage: $0 <result to be analyzed> <number of threads>"
+  echo; echo "eg:"
+  echo; echo "    # $0 fuse-mount-large-file-result.txt 16"
+  exit
+fi
+
+NoOfThreads=$2
+
+declare -A Operations
+
+Operations=( ["seq-write"]="initial writers" ["seq-read"]="$NoOfThreads readers" ["random-read"]="random readers"  ["random-write"]="random writers" )
+
+for key in ${!Operations[@]}
+do
+    if [ "$key"  = "seq-read" ]
+    then
+        grep -i "${Operations[$key]}" $1 | awk  -v ops="$key"  -v PREC=100 -v CONVFMT=%.17g  'BEGIN{ sum = 0} {sum+=sprintf("%f",$8)} END{print ops " : " sum/NR}' >> /tmp/$$-lr
+    else
+        grep -i "${Operations[$key]}" $1 | awk  -v ops="$key"  -v PREC=100 -v CONVFMT=%.17g  'BEGIN{ sum = 0} {sum+=sprintf("%f",$9)} END{print ops " : " sum/NR}'  >> /tmp/$$-lr
+    fi
+done
+
+
+sort -r /tmp/$$-lr

--- a/extract-smallfile-results.sh
+++ b/extract-smallfile-results.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ $# -ne 1  ]
+then
+  echo; echo "Usage: $0 <result to be analyzed> "
+  echo; echo "eg:"
+  echo; echo "    # $0 fuse-mount-small-file-result.txt "
+  exit
+fi
+
+Operations=( "create" "ls-l" "chmod" "stat" "read" "append" ": rename" "delete-renamed" "mkdir" "rmdir" "cleanup" )
+
+for (( i = 0; i < ${#Operations[@]} ; i++ ))
+do
+    if [ "${Operations[$i]}"  = "read" -o "${Operations[$i]}"  = "delete-renamed" -o "${Operations[$i]}" = "mkdir" -o "${Operations[$i]}" = "rmdir" ]
+    then
+        egrep -i "operation|^files/sec" $1 | grep -A 1 -i "${Operations[$i]}" | grep -i files | awk  -v ops=$(echo "${Operations[$i]}" | tr -d ' :')  -v PREC=100 -v CONVFMT=%.17g  'BEGIN{ sum = 0} {sum+=sprintf("%f",$3)} END{print ops ": " sum/NR}'
+    else
+        egrep -i "operation|^files/sec" $1 | grep -A 1 -i "${Operations[$i]}" | grep -i files | tail -n +2 | awk  -v ops=$(echo "${Operations[$i]}" | tr -d ' :')  -v PREC=100 -v CONVFMT=%.17g  'BEGIN{ sum = 0} {sum+=sprintf("%f",$3)} END{print ops ": " sum/NR}'
+    fi
+done
+
+


### PR DESCRIPTION
The names of the scripts which parses the file to
extract the results haven been given consistent
and appropriate names.

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>