### PR TITLE
Set appropriate volume options for large file

### DIFF
--- a/perftest.yml
+++ b/perftest.yml
@@ -109,9 +109,6 @@
      gluster_cluster_options:
        diagnostics.count-fop-hits: 'on'
        diagnostics.latency-measurement: 'on'
-       server.event-threads: '4'
-       client.event-threads: '4'
-       cluster.lookup-optimize: 'on'
        network.inode-lru-limit: '200000'
        performance.md-cache-timeout: '600'
        performance.cache-invalidation: 'on'
@@ -119,6 +116,14 @@
        features.cache-invalidation-timeout: '600'
        features.cache-invalidation: 'on'
        nfs.disable: 'off'
+
+  pre_tasks:
+    - name: setting appropriate gluster options for smallfile
+      set_fact:
+        gluster_cluster_options: "{{ gluster_cluster_options | combine({'server.event-threads': '4'})}}"
+        gluster_cluster_options: "{{ gluster_cluster_options | combine({'client.event-threads:': '4'})}}"
+        gluster_cluster_options: "{{ gluster_cluster_options | combine({'cluster.lookup-optimize': 'on'})}}"
+      when: tool == "smallfile"
 
   roles:
      - gluster.infra


### PR DESCRIPTION
Large file test was using the same volume options as smallfile
which is changed via this patch. The extra volume options needed
by smallfile test are set only if the test executed is smallfile
test.

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>