### PR TITLE
Ensured python3 is existing on RHEL8

### DIFF
--- a/perftest.yml
+++ b/perftest.yml
@@ -58,7 +58,7 @@
     - { role: setup-upstream-repo, when: build == "upstream" }
 
 - name: Subscribe to RHSM
-  hosts: master_client
+  hosts: cluster_machines
   remote_user: root
   gather_facts: no
   vars_files:

--- a/roles/gluster-client-setup/tasks/main.yml
+++ b/roles/gluster-client-setup/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install glusterfs-fuse
   yum:
-    name: [ 'glusterfs-fuse', 'git' ]
+    name: [ 'glusterfs-fuse', 'git' , 'python3' ]
     state: present
   retries: 10
   delay: 5
@@ -23,6 +23,19 @@
     state: link
   when: inventory_hostname == groups['master_client'].0
   ignore_errors: yes
+
+- name: create a symlink for python3
+  file:
+    src: /usr/bin/python3
+    dest: /usr/bin/python
+    owner: root
+    group: root
+    state: link
+  ignore_errors: yes
+
+- name: waiting
+  pause:
+    prompt: Check if above python3 installation was successfull
 
 - name: distribute the ssh key to the remote hosts
   shell: "/usr/bin/sshpass -p \"{{ remote_machine_password }}\" ssh-copy-id -f -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/{{ ssh_key_filename }}.pub  \"{{ remote_machine_username }}@{{ item }}\""

--- a/roles/install-and-start-gluster/tasks/main.yml
+++ b/roles/install-and-start-gluster/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install Gluster and additional packages on servers
   yum:
-    name: ['python3', 'policycoreutils-python', 'glusterfs-server', 'glusterfs-fuse', 'glusterfs-api' ]
+    name: ['python3',  'glusterfs-server', 'glusterfs-fuse', 'glusterfs-api' ]
     state: present
   retries: 10
   delay: 5


### PR DESCRIPTION
Python3 was not installed on RHEL8 by default
this patch installs python3

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>