### PR TITLE
Added Python3 for RHEL8

### DIFF
--- a/roles/gluster-client-setup/tasks/main.yml
+++ b/roles/gluster-client-setup/tasks/main.yml
@@ -1,10 +1,20 @@
 ---
 - name: Install glusterfs-fuse
   yum:
-    name: [ 'glusterfs-fuse', 'git' , 'python3' ]
+    name: [ 'glusterfs-fuse', 'git' ]
     state: present
   retries: 10
   delay: 5
+
+- name: Install glusterfs-fuse
+  yum:
+    name: [ 'python3' ]
+    state: present
+  retries: 10
+  delay: 5
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "8"
 
 - name: Install additional packages on master client
   yum:
@@ -32,6 +42,9 @@
     group: root
     state: link
   ignore_errors: yes
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "8"
 
 - name: distribute the ssh key to the remote hosts
   shell: "/usr/bin/sshpass -p \"{{ remote_machine_password }}\" ssh-copy-id -f -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/{{ ssh_key_filename }}.pub  \"{{ remote_machine_username }}@{{ item }}\""


### PR DESCRIPTION
As python3 was not present on the installed RHEL8
ditro, smallfile test was unable to run on it. So
this patch makes sure python3 is present on RHEL8

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>