### PR TITLE
Fixing gluster volume options set for smallfile

### DIFF
--- a/perftest.yml
+++ b/perftest.yml
@@ -120,9 +120,7 @@
   pre_tasks:
     - name: setting appropriate gluster options for smallfile
       set_fact:
-        gluster_cluster_options: "{{ gluster_cluster_options | combine({'server.event-threads': '4'})}}"
-        gluster_cluster_options: "{{ gluster_cluster_options | combine({'client.event-threads:': '4'})}}"
-        gluster_cluster_options: "{{ gluster_cluster_options | combine({'cluster.lookup-optimize': 'on'})}}"
+        gluster_cluster_options: "{{ gluster_cluster_options | combine({'server.event-threads': '4', 'client.event-threads': '4', 'cluster.lookup-optimize': 'on'})}}"
       when: tool == "smallfile"
 
   roles:


### PR DESCRIPTION
Some of the volume options for smallfile did not
get set and a warning was thrown instead. This
patch fixes that.

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>