### PR TITLE
Nodocs configured only for RHEL as it fails on fedora

### DIFF
--- a/roles/common-setup/tasks/main.yml
+++ b/roles/common-setup/tasks/main.yml
@@ -4,8 +4,16 @@
     name: root
     generate_ssh_key: true
 
+- name: Gather required facts
+  setup:
+    gather_subset:
+      - '!all'
+      - 'ohai'
+
 - name: Edit yum.conf to not install docs
   lineinfile:
     path: '/etc/yum.conf'
     state: present
     line: 'tstflags=nodocs'
+  when: ansible_distribution == "RedHat"
+


### PR DESCRIPTION
Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>