### PR TITLE
Collect pcp logs from cluster machines

### DIFF
--- a/perftest.yml
+++ b/perftest.yml
@@ -152,6 +152,23 @@
   roles:
     - execute-perf-and-get-results
 
+- name: Fetch pcplogs from all the machines
+  hosts: cluster_machines
+  remote_user: root
+  tasks:
+    - name: Find pcplogs
+      find :
+        paths: /var/log/pcp/pmlogger/
+        recurse: yes
+      register: files_to_copy
+
+    - name: Get pcplogs
+      fetch:
+        src: "{{ item.path }}"
+        dest: "{{ download_results_at_location }}/results/pcplogs"
+      with_items: "{{ files_to_copy.files }}"
+      ignore_errors: yes
+
 - name: delete the ssh key if specifically asked
   hosts: control_machine
   tasks:

--- a/roles/common-setup/tasks/main.yml
+++ b/roles/common-setup/tasks/main.yml
@@ -17,3 +17,19 @@
     line: 'tstflags=nodocs'
   when: ansible_distribution == "RedHat"
 
+- name: Install pcp
+  yum:
+    name: ['pcp-zeroconf']
+    state: present
+  retries: 10
+  delay: 5
+
+- name: Start pcp services
+  systemd:
+    name: "{{ item }}"
+    daemon_reload: yes
+    state: restarted
+  with_items:
+   - 'pmcd'
+   - 'pmlogger'
+


### PR DESCRIPTION
This patch installs pcp on the cluster machine.
Starts the pcp service to collect the metrics.
Collect the pcp logs from all the machines.

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>