### PR TITLE
Added time-stamp before and after test

### DIFF
--- a/largefile-test-for-fuse-with-fio.sh
+++ b/largefile-test-for-fuse-with-fio.sh
@@ -14,6 +14,7 @@ LogFile="/var/log/PerfTestClient.log"
 TestCase=("sequential-write" "sequential-read" "random-write" "random-read")
 
 ssh root@$ServerNode "echo Largefile using fio TestStarts > /var/log/PerfTest.log  2>&1"
+ssh root@$ServerNode "date >> /var/log/PerfTest.log  2>&1"
 scp /root/collect-info.sh root@$ServerNode:/tmp/
 ssh root@$ServerNode "/tmp/collect-info.sh >> /var/log/PerfTest.log  2>&1"
 ssh root@$ServerNode "gluster volume info >> /var/log/PerfTest.log 2>&1"
@@ -60,6 +61,7 @@ tar cf fuse-fio-result.tar fuse-fio-result
 
 
 ssh root@$ServerNode "echo Testover  >> /var/log/PerfTest.log  2>&1"
+ssh root@$ServerNode "date >> /var/log/PerfTest.log  2>&1"
 scp root@$ServerNode:/var/log/PerfTest.log /root/
 
 # Log the client config

--- a/largefile-test-for-fuse.sh
+++ b/largefile-test-for-fuse.sh
@@ -17,6 +17,7 @@ Options=( "-i 0 -s 8g" "-i 1 -s 8g" "-i 2 -s 2g -J 3 -I" )
 TestName=("sequential-write-rewrite" "sequential-read-reread" "random-read-write" )
 
 ssh root@$ServerNode "echo Largefile using Iozone TestStarts > /var/log/PerfTest.log  2>&1"
+ssh root@$ServerNode "date >> /var/log/PerfTest.log  2>&1"
 scp /root/collect-info.sh root@$ServerNode:/tmp/
 ssh root@$ServerNode "/tmp/collect-info.sh >> /var/log/PerfTest.log  2>&1"
 ssh root@$ServerNode "gluster volume info >> /var/log/PerfTest.log 2>&1"
@@ -49,6 +50,7 @@ scp root@$ServerNode:/root/*.txt /root/fuse-largefile-profile-iozone/
 tar cf fuse-largefile-profile-iozone.tar fuse-largefile-profile-iozone
 
 ssh root@$ServerNode "echo Testover  >> /var/log/PerfTest.log  2>&1"
+ssh root@$ServerNode "date >> /var/log/PerfTest.log  2>&1"
 scp root@$ServerNode:/var/log/PerfTest.log /root/
 
 # Log the client config

--- a/smallfile-test-for-fuse.sh
+++ b/smallfile-test-for-fuse.sh
@@ -14,6 +14,7 @@ fi
 ServerNode=$1
 
 ssh root@$ServerNode "echo Smallfile TestStarts > /var/log/PerfTest.log  2>&1"
+ssh root@$ServerNode "date >> /var/log/PerfTest.log  2>&1"
 scp /root/collect-info.sh root@$ServerNode:/tmp/
 ssh root@$ServerNode "/tmp/collect-info.sh >> /var/log/PerfTest.log  2>&1"
 ssh root@$ServerNode "gluster volume info >> /var/log/PerfTest.log 2>&1"
@@ -42,6 +43,7 @@ ssh root@$ServerNode "gluster volume info  > /root/volume-info.txt"
 scp root@$ServerNode:/root/*.txt /root/fuse-smallfile-profile/
 tar cf fuse-smallfile-profile.tar fuse-smallfile-profile
 ssh root@$ServerNode "echo Testover  >> /var/log/PerfTest.log  2>&1"
+ssh root@$ServerNode "date >> /var/log/PerfTest.log  2>&1"
 scp root@$ServerNode:/var/log/PerfTest.log /root/
 
 # Log the client config


### PR DESCRIPTION
This patch collects time-stamp just before starting
the test and just after stopping the test which
will be useful while analyzing  pcplogs.

Signed-off-by: Rinku Kothiya <rkothiya@redhat.com>